### PR TITLE
fix: remove duplicate export in swaggerOptions.js

### DIFF
--- a/src/swaggerOptions.js
+++ b/src/swaggerOptions.js
@@ -47,7 +47,7 @@ const swaggerOptions = {
 
 const specs = swaggerJSDoc(swaggerOptions);
 
-export const swaggerUiOptions = {
+const swaggerUiOptions = {
   explorer: true,
   customCss: `
     .swagger-ui .topbar {display: none}


### PR DESCRIPTION
fix: remove duplicate export in swaggerOptions.js